### PR TITLE
fix: preempt schemas into being objects

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -116,7 +116,8 @@
   },
   "definitions": {
     "schema": {
-      "$ref": "https://json-schema.org/draft-07/schema#"
+      "$ref": "https://json-schema.org/draft-07/schema#",
+      "type": "object"
     },
     "vendorExtensions": {
       "type": "object",

--- a/schema.json
+++ b/schema.json
@@ -117,7 +117,8 @@
   "definitions": {
     "schema": {
       "$ref": "https://json-schema.org/draft-07/schema#",
-      "type": "object"
+      "type": "object",
+      "default": {}
     },
     "vendorExtensions": {
       "type": "object",


### PR DESCRIPTION
fixes #27 
This doesnt seem to fix playgrounds autocompleting problem, but at least it's giving an error that schema must be an object...

I'm not sure this is really an improvement though.