### PR TITLE
fix: Update schema according to latest spec

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -9,6 +9,9 @@
     "openrpc"
   ],
   "additionalProperties": false,
+  "patternProperties": {
+    "^x-": {}
+  },
   "properties": {
     "openrpc": {
       "title": "openrpc",
@@ -56,6 +59,14 @@
             }
           }
         },
+        "errors": {
+          "type": "object",
+          "patternProperties": {
+            "[0-z]+": {
+              "$ref": "#/definitions/errorObject"
+            }
+          }
+        },
         "examples": {
           "title": "exampleComponents",
           "type": "object",
@@ -65,6 +76,7 @@
             }
           }
         },
+
         "examplePairings": {
           "title": "examplePairingComponents",
           "type": "object",
@@ -378,10 +390,11 @@
         "paramStructure": {
           "title": "methodObjectParamStructure",
           "type": "string",
-          "description": "Format the server expects the params. Defaults to 'by-positon'.",
+          "description": "Format the server expects the params. Defaults to 'by-position'.",
           "enum": [
             "by-position",
-            "by-name"
+            "by-name",
+            "either"
           ],
           "default": "by-position"
         },


### PR DESCRIPTION
This PR syncs the schema with the latest documented specification (as far as I can find, at least).

* Allow specification extensions (`x-*`) on root level: https://spec.open-rpc.org/#openrpc-object
* Add missing `components.errors` definition: https://spec.open-rpc.org/#components-object
* Add enum value `either` to `paramStructure`: https://spec.open-rpc.org/#method-object
* ~Add new component `errorGroups`, as discussed here: https://github.com/open-rpc/spec/pull/245 — let me know if I can help move this PR forward (I've validated that it solves our issue as discussed in the issue related to the PR)~ Will be sorted in a separate PR once approach has been decided


Fixes #156 