### PR TITLE
feat(go): import encoding/json if need be

### DIFF
--- a/bin/build.js
+++ b/bin/build.js
@@ -21,16 +21,25 @@ const generateTypes = async (s) => {
 
   const transpiler = new JsonSchemaToTypes(parsed);
   const ts = transpiler.toTs();
- 
+
+  // Check if our generated macros use json.Un/Marshal.
+  // If so, add the standard json package as an import.
+  const transpiled = transpiler.toGo();
+  var imports = "";
+  if (/json\.(Un|)Marshal/g.test(transpiled)) {
+    imports += `import "encoding/json"`
+  }
+
   const go = [
     "package meta_schema",
     "",
+    `${imports}`,
     "",
     `const MetaSchemaJSON = "${escapedS}"`,
     "",
-    transpiler.toGo(),
+    transpiled,
   ].join("\n");
-  
+
   const dir = path.resolve(__dirname, "../build/src/");
   const goDir = path.resolve(__dirname, "../");
   await ensureDir(dir);


### PR DESCRIPTION
AnyOf types in particular need special json un/marshaling
handling, which is done by implementing JSONMarshaler
and JSONUnmarshaler interfaces for the type. Often
these implementations delegate eventual marshaling
of children fields to the standard lib json package.

This provides the document with the necessary import
statement if it appears it needs it.

Signed-off-by: meows <b5c6@protonmail.com>