### PR TITLE
fix: change to using non-github url for meta schema

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "dependencies": {},
   "devDependencies": {
     "@etclabscore/dl-github-releases": "^1.2.1",
+    "@json-schema-tools/dereferencer": "^1.2.6",
     "@json-schema-tools/semantic-release-transpiler": "1.4.5",
     "@qiwi/semantic-release-gh-pages-plugin": "^5.0.0",
     "@semantic-release/changelog": "^5.0.1",

--- a/schema.json
+++ b/schema.json
@@ -118,9 +118,9 @@
       "title": "specificationExtension"
     },
     "JSONSchema": {
-      "$ref": "https://raw.githubusercontent.com/json-schema-tools/meta-schema/1.3.0/src/schema.json"
+      "$ref": "https://meta.json-schema.tools/"
     },
-    "referenceObject": { 
+    "referenceObject": {
       "title": "referenceObject",
       "type": "object",
       "additionalProperties": false,
@@ -129,7 +129,7 @@
       ],
       "properties": {
         "$ref": {
-           "$ref": "https://raw.githubusercontent.com/json-schema-tools/meta-schema/1.3.0/src/schema.json#definitions/JSONSchemaObject/properties/$ref"
+          "$ref": "https://meta.json-schema.tools/#definitions/JSONSchemaObject/properties/$ref"
         }
       }
     },

--- a/src/test.ts
+++ b/src/test.ts
@@ -1,10 +1,26 @@
 import * as fs from "fs";
+import Dereferencer from "@json-schema-tools/dereferencer";
+import dereffer from "@json-schema-tools/dereferencer";
 
 describe("meta-schema", () => {
+  const s = fs.readFileSync("./schema.json", "utf8");
+  let schema = false;
+  try {
+    schema = JSON.parse(s);
+  } catch (e) { }
 
   it("is valid json", () => {
-    const schema = fs.readFileSync("./schema.json", "utf8");
-    const asJson = JSON.parse(schema);
-    expect(asJson.type).toBe("object");
+    expect(schema).toBeTruthy();
+  });
+
+  it("has references that are valid", async () => {
+    expect.assertions(4);
+    const deref = new Dereferencer(schema);
+    const dereffed = await deref.resolve();
+    expect(dereffed).toBeTruthy();
+    console.log(dereffed);
+    expect(dereffed.definitions).not.toBeDefined();
+    expect(dereffed.properties.methods.items.properties.result.oneOf[0].properties.schema.title).toBe("JSONSchema");
+    expect(dereffed.properties.methods.items.properties.result.oneOf[1].title).toBe("referenceObject");
   });
 });


### PR DESCRIPTION
Im not 100% that we should do this until we have versioned urls for the meta.json-schema.tools urls.

It brings up an interesting question about json-schema.tools versioning of the meta schema independent of json-schema version itself, similar to how we have open-rpc/spec & meta schema versions decoupled ATM. 

We may want to also reconsider how we manage this repo - perhaps having a meta-schema for each version of open-rpc would make more sense than current setup (1 schema for all, but with an enum for version).