### PR TITLE
fix: use standard naming convention of methodOrReference

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -39,7 +39,7 @@
       "type": "array",
       "additionalItems": false,
       "items": {
-        "title": "methodReference",
+        "title": "methodOrReference",
         "oneOf": [
           {
             "$ref": "#/definitions/methodObject"
@@ -128,7 +128,7 @@
     "JSONSchema": {
       "$ref": "https://raw.githubusercontent.com/json-schema-tools/meta-schema/1.5.9/src/schema.json"
     },
-    "referenceObject": { 
+    "referenceObject": {
       "title": "referenceObject",
       "type": "object",
       "additionalProperties": false,


### PR DESCRIPTION
fixes #385