### PR TITLE
allow OpenRPC document to specify $schema

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -119,7 +119,12 @@
           }
         }
       }
-    }
+    },
+    "$schema": {
+       "description": "JSON Schema URI (used by some editors)",
+       "type": "string",
+       "default": "https://raw.githubusercontent.com/json-schema-tools/meta-schema/1.5.9/src/schema.json"
+     }
   },
   "definitions": {
     "specificationExtension": {

--- a/schema.json
+++ b/schema.json
@@ -123,7 +123,7 @@
     "$schema": {
        "description": "JSON Schema URI (used by some editors)",
        "type": "string",
-       "default": "https://raw.githubusercontent.com/json-schema-tools/meta-schema/1.5.9/src/schema.json"
+       "default": "https://meta.open-rpc.org/"
      }
   },
   "definitions": {


### PR DESCRIPTION
Allows to specify the `$schema` in the OpenRPC document.
This helps in development when the OpenRPC extension doesn't have the required version of the schema automatically or for IDEs without a specific extension.

See examples in other projects:
- https://github.com/DavidAnson/markdownlint/issues/227 
- https://github.com/OAI/OpenAPI-Specification/issues/1719