### PR TITLE
feat: discriminator

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -132,7 +132,31 @@
       "title": "specificationExtension"
     },
     "JSONSchema": {
-      "$ref": "https://raw.githubusercontent.com/json-schema-tools/meta-schema/1.5.9/src/schema.json"
+      "allOf": [
+        {
+          "$ref": "https://raw.githubusercontent.com/json-schema-tools/meta-schema/1.5.9/src/schema.json"
+        },
+        {
+          "$ref": "#/definitions/discriminatorObject"
+        }
+      ]
+    },
+    "discriminatorObject": {
+      "type": "object",
+      "required": [
+        "propertyName"
+      ],
+      "properties": {
+        "propertyName": {
+          "type": "string"
+        },
+        "mapping": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
     },
     "referenceObject": {
       "title": "referenceObject",

--- a/src/test.ts
+++ b/src/test.ts
@@ -20,7 +20,7 @@ describe("meta-schema", () => {
     const dereffed = await deref.resolve();
     expect(dereffed).toBeTruthy();
     expect(dereffed.definitions).not.toBeDefined();
-    expect(dereffed.properties.methods.items.oneOf[0].properties.result.oneOf[0].properties.schema.title).toBe("JSONSchema");
+    expect(dereffed.properties.methods.items.oneOf[0].properties.result.oneOf[0].properties.schema.allOf[0].title).toBe("JSONSchema");
     expect(dereffed.properties.methods.items.oneOf[0].properties.result.oneOf[1].title).toBe("referenceObject");
   });
 });


### PR DESCRIPTION
I'm proposing adding a discriminator similar to the OpenAPI discriminator feature:
https://swagger.io/docs/specification/data-models/inheritance-and-polymorphism/

This would address the following feature requests: https://github.com/open-rpc/spec/issues/382 https://github.com/open-rpc/spec/issues/367

And in general be predictable for anyone who worked with OpenAPI before coming to OpenRPC.

The main use case is code generation of API clients in cases where a method might return more than one type of value based on parameters passed.

Small disclaimer:
I think my use of `allOf` should compile correctly? But if not, upon conceptual agreement from maintainers I'm willing to make sure everything works as intended, as well as potentially introduce proper support for this in the playground. 